### PR TITLE
feat(billing):課金ページの見た目のみ実装 #12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10820,6 +10820,11 @@
         "opencollective-postinstall": "^2.0.2"
       }
     },
+    "ngx-stripe": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/ngx-stripe/-/ngx-stripe-9.0.2.tgz",
+      "integrity": "sha512-rc5cks54Zh5sNGF18tTrxVlsPox9tG/ABu5rl/CqxpzAW2BWGYtSO3DoUBP8DTND7ysKBhTIMtXP2o4or6lZvg=="
+    },
     "ngx-swiper-wrapper": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/ngx-swiper-wrapper/-/ngx-swiper-wrapper-8.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "instantsearch.css": "^7.4.2",
     "instantsearch.js": "^4.3.1",
     "ngx-infinite-scroll": "^8.0.1",
+    "ngx-stripe": "^9.0.2",
     "ngx-swiper-wrapper": "^8.0.2",
     "rxjs": "~6.4.0",
     "tslib": "^1.10.0",

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -69,11 +69,9 @@ const routes: Routes = [
     canActivate: [AuthGuard]
   },
   {
-    path: 'favvocabulary',
+    path: 'billing',
     loadChildren: () =>
-      import('./favvocabulary/favvocabulary.module').then(
-        m => m.FavvocabularyModule
-      ),
+      import('./billing/billing.module').then(m => m.BillingModule),
     canLoad: [AuthGuard],
     canActivate: [AuthGuard]
   },
@@ -118,6 +116,15 @@ const routes: Routes = [
     path: 'mode',
     loadChildren: () =>
       import('./result/result.module').then(m => m.ResultModule),
+    canLoad: [AuthGuard],
+    canActivate: [AuthGuard]
+  },
+  {
+    path: 'favvocabulary',
+    loadChildren: () =>
+      import('./favvocabulary/favvocabulary.module').then(
+        m => m.FavvocabularyModule
+      ),
     canLoad: [AuthGuard],
     canActivate: [AuthGuard]
   },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,7 +13,8 @@ import {
   MatProgressBarModule,
   MatInputModule,
   MatAutocompleteModule,
-  MatFormFieldModule
+  MatFormFieldModule,
+  MatDialogModule
 } from '@angular/material';
 import { FooterComponent } from './footer/footer.component';
 import { AngularFireModule } from '@angular/fire';
@@ -26,13 +27,15 @@ import { NotfoundComponent } from './notfound/notfound.component';
 import { SharedModule } from './shared/shared.module';
 import { NgAisModule } from 'angular-instantsearch';
 import { ReactiveFormsModule } from '@angular/forms';
-
+import { BillingDialogComponent } from './billing-dialog/billing-dialog.component';
+import { NgxStripeModule } from 'ngx-stripe';
 @NgModule({
   declarations: [
     AppComponent,
     HeaderComponent,
     FooterComponent,
-    NotfoundComponent
+    NotfoundComponent,
+    BillingDialogComponent
   ],
   imports: [
     BrowserModule,
@@ -54,7 +57,9 @@ import { ReactiveFormsModule } from '@angular/forms';
     MatInputModule,
     MatAutocompleteModule,
     MatFormFieldModule,
-    ReactiveFormsModule
+    ReactiveFormsModule,
+    MatDialogModule,
+    NgxStripeModule.forRoot('***your-stripe-publishable key***')
   ],
   providers: [
     {
@@ -62,6 +67,7 @@ import { ReactiveFormsModule } from '@angular/forms';
       useValue: 'asia-northeast1'
     }
   ],
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
+  entryComponents: [BillingDialogComponent]
 })
 export class AppModule {}

--- a/src/app/billing-dialog/billing-dialog.component.html
+++ b/src/app/billing-dialog/billing-dialog.component.html
@@ -1,0 +1,19 @@
+<div mat-dialog-content>
+  <p>クレジットカードを登録</p>
+  <form novalidate (ngSubmit)="buy()" [formGroup]="stripeTest">
+    <div id="card-element" class="field"></div>
+    <mat-form-field>
+      <mat-label>名前</mat-label>
+      <input
+        matInput
+        type="text"
+        formControlName="name"
+        placeholder="Ymada Taro"
+      />
+    </mat-form-field>
+    <div mat-dialog-actions>
+      <button mat-button mat-raised-button color="primary">登録する</button>
+      <button mat-button matDialogClose cdkFocusInitial>キャンセル</button>
+    </div>
+  </form>
+</div>

--- a/src/app/billing-dialog/billing-dialog.component.scss
+++ b/src/app/billing-dialog/billing-dialog.component.scss
@@ -1,0 +1,6 @@
+.mat-dialog-actions {
+  margin-bottom: -15px;
+}
+mat-form-field {
+  width: 100%;
+}

--- a/src/app/billing-dialog/billing-dialog.component.spec.ts
+++ b/src/app/billing-dialog/billing-dialog.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BillingDialogComponent } from './billing-dialog.component';
+
+describe('BillingDialogComponent', () => {
+  let component: BillingDialogComponent;
+  let fixture: ComponentFixture<BillingDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [BillingDialogComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BillingDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/billing-dialog/billing-dialog.component.ts
+++ b/src/app/billing-dialog/billing-dialog.component.ts
@@ -1,0 +1,64 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import {
+  StripeService,
+  Elements,
+  Element as StripeElement,
+  ElementsOptions
+} from 'ngx-stripe';
+
+@Component({
+  selector: 'app-billing-dialog',
+  templateUrl: './billing-dialog.component.html',
+  styleUrls: ['./billing-dialog.component.scss']
+})
+export class BillingDialogComponent implements OnInit {
+  elements: Elements;
+  card: StripeElement;
+
+  // optional parameters
+  elementsOptions: ElementsOptions = {
+    locale: 'es'
+  };
+
+  stripeTest: FormGroup;
+  constructor(private fb: FormBuilder, private stripeService: StripeService) {}
+
+  ngOnInit() {
+    this.stripeTest = this.fb.group({
+      name: ['', [Validators.required]]
+    });
+    this.stripeService.elements(this.elementsOptions).subscribe(elements => {
+      this.elements = elements;
+      if (!this.card) {
+        this.card = this.elements.create('card', {
+          style: {
+            base: {
+              iconColor: '#666EE8',
+              color: '#31325F',
+              lineHeight: '40px',
+              fontWeight: 300,
+              fontFamily: '"Helvetica Neue", Helvetica, sans-serif',
+              fontSize: '18px',
+              '::placeholder': {
+                color: '#CFD7E0'
+              }
+            }
+          }
+        });
+        this.card.mount('#card-element');
+      }
+    });
+  }
+
+  buy() {
+    const name = this.stripeTest.get('name').value;
+    this.stripeService.createToken(this.card, { name }).subscribe(result => {
+      if (result.token) {
+        return result.token;
+      } else if (result.error) {
+        return result.error.message;
+      }
+    });
+  }
+}

--- a/src/app/billing-dialog/billing-dialog.component.ts
+++ b/src/app/billing-dialog/billing-dialog.component.ts
@@ -18,7 +18,7 @@ export class BillingDialogComponent implements OnInit {
 
   // optional parameters
   elementsOptions: ElementsOptions = {
-    locale: 'es'
+    locale: 'ja'
   };
 
   stripeTest: FormGroup;

--- a/src/app/billing/billing-routing.module.ts
+++ b/src/app/billing/billing-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { BillingComponent } from './billing/billing.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: BillingComponent
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class BillingRoutingModule {}

--- a/src/app/billing/billing.module.ts
+++ b/src/app/billing/billing.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { BillingRoutingModule } from './billing-routing.module';
+import { BillingComponent } from './billing/billing.component';
+import {
+  MatCardModule,
+  MatButtonModule,
+  MatIconModule,
+  MatDialogModule
+} from '@angular/material';
+
+@NgModule({
+  declarations: [BillingComponent],
+  imports: [
+    CommonModule,
+    BillingRoutingModule,
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+    MatDialogModule
+  ]
+})
+export class BillingModule {}

--- a/src/app/billing/billing/billing.component.html
+++ b/src/app/billing/billing/billing.component.html
@@ -13,7 +13,7 @@
           単語帳作成数
         </p>
       </div>
-      <p class="detail detail--bold">無制限</p>
+      <p class="detail">無制限</p>
       <div class="body__content">
         <mat-icon color="primary">
           style
@@ -47,7 +47,7 @@
           単語帳作成数
         </p>
       </div>
-      <p class="detail detail--bold">無制限</p>
+      <p class="detail">無制限</p>
       <div class="body__content">
         <mat-icon color="primary">
           style
@@ -56,7 +56,7 @@
           単語作成数
         </p>
       </div>
-      <p class="detail detail--bold">無制限</p>
+      <p class="detail">無制限</p>
     </mat-card-content>
     <button (click)="openDialog()" mat-raised-button color="primary">
       このプランに変更する

--- a/src/app/billing/billing/billing.component.html
+++ b/src/app/billing/billing/billing.component.html
@@ -1,0 +1,65 @@
+<div class="container">
+  <mat-card>
+    <mat-card-content class="header">
+      <mat-card-title>フリープラン</mat-card-title>
+    </mat-card-content>
+    <mat-card-content class="body">
+      <div class="body__price">¥0</div>
+      <div class="body__content">
+        <mat-icon color="primary">
+          import_contacts
+        </mat-icon>
+        <p class="sub-title">
+          単語帳作成数
+        </p>
+      </div>
+      <p class="detail detail--bold">無制限</p>
+      <div class="body__content">
+        <mat-icon color="primary">
+          style
+        </mat-icon>
+        <p class="sub-title">
+          単語作成数
+        </p>
+      </div>
+      <p class="detail">10個</p>
+    </mat-card-content>
+    <button [disabled]="true" mat-raised-button color="primary">
+      このプランに変更する
+    </button>
+  </mat-card>
+  <mat-card>
+    <mat-card-content class="header">
+      <mat-card-title>月額プラン</mat-card-title>
+    </mat-card-content>
+    <mat-card-content class="body">
+      <div class="body__price">
+        <div>
+          ¥100
+        </div>
+        <p>+税/月</p>
+      </div>
+      <div class="body__content">
+        <mat-icon color="primary">
+          import_contacts
+        </mat-icon>
+        <p class="sub-title">
+          単語帳作成数
+        </p>
+      </div>
+      <p class="detail detail--bold">無制限</p>
+      <div class="body__content">
+        <mat-icon color="primary">
+          style
+        </mat-icon>
+        <p class="sub-title">
+          単語作成数
+        </p>
+      </div>
+      <p class="detail detail--bold">無制限</p>
+    </mat-card-content>
+    <button (click)="openDialog()" mat-raised-button color="primary">
+      このプランに変更する
+    </button>
+  </mat-card>
+</div>

--- a/src/app/billing/billing/billing.component.scss
+++ b/src/app/billing/billing/billing.component.scss
@@ -5,14 +5,17 @@
   justify-content: center;
   padding-top: 16px;
 }
+
 mat-card {
   display: flex;
   flex-flow: column;
 }
+
 .body,
 button {
   margin: 0 16px 16px;
 }
+
 .body {
   flex: 1;
   &__content {
@@ -34,10 +37,12 @@ button {
     }
   }
 }
+
 .sub-title {
   color: rgba(black, 0.6);
   margin-bottom: 0;
 }
+
 .detail {
   margin-top: 0;
   font-size: 20px;

--- a/src/app/billing/billing/billing.component.scss
+++ b/src/app/billing/billing/billing.component.scss
@@ -1,0 +1,45 @@
+.container {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, 300px);
+  justify-content: center;
+  padding-top: 16px;
+}
+mat-card {
+  display: flex;
+  flex-flow: column;
+}
+.body,
+button {
+  margin: 0 16px 16px;
+}
+.body {
+  flex: 1;
+  &__content {
+    display: flex;
+    justify-content: center;
+    mat-icon {
+      line-height: 2.3;
+      margin-right: 1px;
+      font-size: 20px;
+    }
+  }
+  &__price {
+    display: flex;
+    justify-content: center;
+    font-size: 24px;
+    font-weight: 500;
+    p {
+      font-size: 10px;
+    }
+  }
+}
+.sub-title {
+  color: rgba(black, 0.6);
+  margin-bottom: 0;
+}
+.detail {
+  margin-top: 0;
+  font-size: 20px;
+  font-weight: 500;
+}

--- a/src/app/billing/billing/billing.component.spec.ts
+++ b/src/app/billing/billing/billing.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BillingComponent } from './billing.component';
+
+describe('BillingComponent', () => {
+  let component: BillingComponent;
+  let fixture: ComponentFixture<BillingComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [BillingComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BillingComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/billing/billing/billing.component.ts
+++ b/src/app/billing/billing/billing.component.ts
@@ -1,0 +1,27 @@
+import { Component, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material';
+import { BillingDialogComponent } from 'src/app/billing-dialog/billing-dialog.component';
+
+@Component({
+  selector: 'app-billing',
+  templateUrl: './billing.component.html',
+  styleUrls: ['./billing.component.scss']
+})
+export class BillingComponent implements OnInit {
+  constructor(private dialog: MatDialog) {}
+
+  ngOnInit() {}
+
+  openDialog() {
+    this.dialog.open(BillingDialogComponent, {
+      width: '640px',
+      autoFocus: false,
+      restoreFocus: false,
+      // ここでデータを渡す
+      data: {
+        name: 'taro',
+        card: 123
+      }
+    });
+  }
+}


### PR DESCRIPTION
## 実装内容
- 課金ページ作成。
- プランのボタンを押したらdialogがでるようにしました。

fix #12 

機能実装は他のissueでやります。
ご確認よろしくお願い致します。

## 挙動
[![Image from Gyazo](https://i.gyazo.com/dbb2578eeb1a0b842d11767b9987373e.gif)](https://gyazo.com/dbb2578eeb1a0b842d11767b9987373e)
