### PR TITLE
feat(billing): stripe連携 #13

### DIFF
--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/download-artifact@master
         with:
           name: dist
+          path: dist
       - name: Install Dependencies
         run: cd functions && npm install
       - name: Deploy to Firebase

--- a/firestore.rules
+++ b/firestore.rules
@@ -36,7 +36,7 @@ service cloud.firestore {
       // 作る、更新、削除はログインした人しかできない
       allow create, update, delete: if isAuthenticated()
     }
-      match /vocabularies/{vocabularyId}/words/{wordId} {
+    match /vocabularies/{vocabularyId}/words/{wordId} {
       // 見ることは誰でもできる
       allow read: if true;
       // 作成者のidがvocabularyIdにあれば
@@ -45,6 +45,9 @@ service cloud.firestore {
       allow update: if request.auth.uid == resource.data.authorId && resource.data.authorId == request.resource.data.authorId;
       // 作った人だけがdeleteできる。resource.dataはこれから作るデータにアクセスできる
       allow delete: if request.auth.uid == resource.data.authorId;
+    }
+    match /customers/{customerId} {
+      allow read, write: if request.auth.uid == customerId;
     }
   }
 }

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -4687,6 +4687,15 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
+    "stripe": {
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.49.0.tgz",
+      "integrity": "sha512-g1JNRsJBCvU3/vhlRJ8sKrC2NkfJ2H1tty8tIOGqF3QTQX/c3lh59Ckj9xmXZtLnQnSWT6iMhkB035Srla6+rw==",
+      "requires": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.6.0"
+      }
+    },
     "stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,7 +17,8 @@
     "algoliasearch": "^4.1.0",
     "firebase-admin": "^8.6.0",
     "firebase-functions": "^3.3.0",
-    "firebase-tools": "^7.16.0"
+    "firebase-tools": "^7.16.0",
+    "stripe": "^8.49.0"
   },
   "devDependencies": {
     "@types/algoliasearch": "^3.34.10",

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -6,3 +6,4 @@ export * from './vocabulary.function';
 export * from './word.function';
 export * from './createcount.function';
 export * from './algolia';
+export * from './stripe.function';

--- a/functions/src/stripe.function.ts
+++ b/functions/src/stripe.function.ts
@@ -1,0 +1,92 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+
+// stripeを初期化
+const stripe = require('stripe')(functions.config().stripe.key);
+const db = admin.firestore();
+const planId = functions.config().stripe.plan_id;
+const taxId = functions.config().stripe.tax_id;
+
+// 顧客作成とサブスク開始関数
+export const createCustomer = functions
+  .region('asia-northeast1')
+  .https.onCall(async (data, context) => {
+    if (!context.auth) {
+      throw new functions.https.HttpsError(
+        'permission-denied',
+        '権限がありません'
+      );
+    }
+    const customer = await stripe.customers.create(data);
+
+    const subscription = await stripe.subscriptions.create({
+      customer: customer.id,
+      default_tax_rates: [taxId],
+      items: [{ plan: planId }]
+    });
+
+    await db.doc(`users/${context.auth?.uid}`).update({
+      isCustomer: true,
+      subscriptionId: subscription.id
+    });
+    // Firestoreの顧客コレクションに顧客IDを記録
+    return db.doc(`customers/${context.auth.uid}`).set({
+      uid: context.auth.uid,
+      customerId: customer.id // 顧客のID
+    });
+  });
+
+// 課金を開始する関数
+export const subscribePlan = functions.region('asia-northeast1').https.onCall(
+  async (
+    data: {
+      customerId: string;
+    },
+    context
+  ) => {
+    if (!context.auth) {
+      throw new Error('認証エラー');
+    }
+
+    const subscription = await stripe.subscriptions.create({
+      customer: data.customerId,
+      default_tax_rates: [taxId],
+      items: [{ plan: planId }]
+    });
+    return db.doc(`users/${context.auth.uid}`).update({
+      isCustomer: true,
+      subscriptionId: subscription.id
+    });
+  }
+);
+
+// 課金停止
+export const unsubscribePlan = functions.region('asia-northeast1').https.onCall(
+  async (
+    data: {
+      userId: string;
+    },
+    context
+  ) => {
+    if (!context.auth) {
+      throw new Error('認証エラー');
+    }
+    const userPayment = (await db.doc(`users/${data.userId}`).get()).data();
+
+    if (!userPayment) {
+      return;
+    }
+    await stripe.subscriptions.del(userPayment.subscriptionId);
+
+    return db.doc(`users/${data.userId}`).update({
+      isCustomer: false,
+      subscriptionId: null
+    });
+  }
+);
+
+// user削除時に課金停止
+export const deleteCustomer = functions.auth.user().onDelete(async user => {
+  const customer = (await db.doc(`customers/${user.uid}`).get()).data();
+  return stripe.customers.del(customer?.customerId);
+});

--- a/functions/src/user.function.ts
+++ b/functions/src/user.function.ts
@@ -9,6 +9,8 @@ export const createUser = functions.auth.user().onCreate(user => {
     id: user.uid,
     userName: user.displayName,
     createdVocabulary: 0,
-    likedVocabulary: 0
+    likedVocabulary: 0,
+    isCustomer: false,
+    createdAt: new Date()
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10821,9 +10821,12 @@
       }
     },
     "ngx-stripe": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/ngx-stripe/-/ngx-stripe-9.0.2.tgz",
-      "integrity": "sha512-rc5cks54Zh5sNGF18tTrxVlsPox9tG/ABu5rl/CqxpzAW2BWGYtSO3DoUBP8DTND7ysKBhTIMtXP2o4or6lZvg=="
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/ngx-stripe/-/ngx-stripe-7.4.4.tgz",
+      "integrity": "sha512-uLuTjtYDIkeBYuzMyjiU36a0ZAAeA5Qi8lZBE+JtQvtQMBpbzluO82GvyKRtMJ08VaP4T6oswPoiGPeigaLr1g==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
     },
     "ngx-swiper-wrapper": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "instantsearch.css": "^7.4.2",
     "instantsearch.js": "^4.3.1",
     "ngx-infinite-scroll": "^8.0.1",
-    "ngx-stripe": "^9.0.2",
+    "ngx-stripe": "^7.4.4",
     "ngx-swiper-wrapper": "^8.0.2",
     "rxjs": "~6.4.0",
     "tslib": "^1.10.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,13 +29,15 @@ import { NgAisModule } from 'angular-instantsearch';
 import { ReactiveFormsModule } from '@angular/forms';
 import { BillingDialogComponent } from './billing-dialog/billing-dialog.component';
 import { NgxStripeModule } from 'ngx-stripe';
+import { ChangeDialogComponent } from './change-dialog/change-dialog.component';
 @NgModule({
   declarations: [
     AppComponent,
     HeaderComponent,
     FooterComponent,
     NotfoundComponent,
-    BillingDialogComponent
+    BillingDialogComponent,
+    ChangeDialogComponent
   ],
   imports: [
     BrowserModule,
@@ -59,7 +61,7 @@ import { NgxStripeModule } from 'ngx-stripe';
     MatFormFieldModule,
     ReactiveFormsModule,
     MatDialogModule,
-    NgxStripeModule.forRoot('***your-stripe-publishable key***')
+    NgxStripeModule.forRoot('pk_test_h4aTKYTOTRM2i8fY3kLn0hyV002rH0glTl')
   ],
   providers: [
     {
@@ -68,6 +70,6 @@ import { NgxStripeModule } from 'ngx-stripe';
     }
   ],
   bootstrap: [AppComponent],
-  entryComponents: [BillingDialogComponent]
+  entryComponents: [BillingDialogComponent, ChangeDialogComponent]
 })
 export class AppModule {}

--- a/src/app/billing-dialog/billing-dialog.component.html
+++ b/src/app/billing-dialog/billing-dialog.component.html
@@ -1,19 +1,55 @@
 <div mat-dialog-content>
-  <p>クレジットカードを登録</p>
-  <form novalidate (ngSubmit)="buy()" [formGroup]="stripeTest">
+  <p matDialogTitle>クレジットカードを登録</p>
+  <form
+    mat-dialog-content
+    novalidate
+    (ngSubmit)="buy()"
+    [formGroup]="stripeTest"
+  >
     <div id="card-element" class="field"></div>
     <mat-form-field>
-      <mat-label>名前</mat-label>
+      <mat-label>カード名義</mat-label>
       <input
         matInput
         type="text"
         formControlName="name"
-        placeholder="Ymada Taro"
+        placeholder="Taro Yamada"
+        autocomplete="off"
       />
+      <mat-error *ngIf="nameControl.hasError('required')"
+        >必須入力です</mat-error
+      >
+      <mat-error *ngIf="nameControl.hasError('maxlength')"
+        >長過ぎます</mat-error
+      >
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>メールアドレス</mat-label>
+      <input
+        matInput
+        type="text"
+        formControlName="email"
+        placeholder="example@email.com"
+        autocomplete="email"
+      />
+      <mat-error *ngIf="emailControl.hasError('required')"
+        >必須入力です</mat-error
+      >
+      <mat-error *ngIf="emailControl.hasError('email')"
+        >正しいメールアドレスの形式で入力してください</mat-error
+      >
     </mat-form-field>
     <div mat-dialog-actions>
-      <button mat-button mat-raised-button color="primary">登録する</button>
-      <button mat-button matDialogClose cdkFocusInitial>キャンセル</button>
+      <button
+        mat-button
+        mat-raised-button
+        color="primary"
+        type="submit"
+        matDialogClose
+      >
+        登録する
+      </button>
+      <button mat-button matDialogClose type="button">キャンセル</button>
     </div>
   </form>
 </div>

--- a/src/app/billing/billing/billing.component.html
+++ b/src/app/billing/billing/billing.component.html
@@ -24,9 +24,19 @@
       </div>
       <p class="detail">10個</p>
     </mat-card-content>
-    <button [disabled]="true" mat-raised-button color="primary">
+    <button
+      *ngIf="isCustomer$ | async; else freeplan"
+      mat-raised-button
+      color="primary"
+      (click)="openChangeDialog()"
+    >
       このプランに変更する
     </button>
+    <ng-template #freeplan>
+      <p class="status">
+        現在ご利用中のプランです
+      </p>
+    </ng-template>
   </mat-card>
   <mat-card>
     <mat-card-content class="header">
@@ -58,8 +68,27 @@
       </div>
       <p class="detail">無制限</p>
     </mat-card-content>
-    <button (click)="openDialog()" mat-raised-button color="primary">
-      このプランに変更する
-    </button>
+    <ng-template #free>
+      <ng-template #first>
+        <button
+          (click)="openSubscribeDialog()"
+          mat-raised-button
+          color="primary"
+        >
+          このプランに変更する
+        </button>
+      </ng-template>
+      <button
+        *ngIf="customerData$ | async; else first"
+        (click)="openChangeDialog()"
+        mat-raised-button
+        color="primary"
+      >
+        このプランに変更する
+      </button>
+    </ng-template>
+    <p *ngIf="isCustomer$ | async as isCustomer; else free" class="status">
+      現在ご利用中のプランです
+    </p>
   </mat-card>
 </div>

--- a/src/app/billing/billing/billing.component.scss
+++ b/src/app/billing/billing/billing.component.scss
@@ -48,3 +48,7 @@ button {
   font-size: 20px;
   font-weight: 500;
 }
+
+.status {
+  margin-top: -16px;
+}

--- a/src/app/billing/billing/billing.component.ts
+++ b/src/app/billing/billing/billing.component.ts
@@ -1,6 +1,13 @@
 import { Component, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material';
 import { BillingDialogComponent } from 'src/app/billing-dialog/billing-dialog.component';
+import { Observable } from 'rxjs';
+import { VocabularyService } from 'src/app/services/vocabulary.service';
+import { AuthService } from 'src/app/services/auth.service';
+import { map } from 'rxjs/operators';
+import { ChangeDialogComponent } from 'src/app/change-dialog/change-dialog.component';
+import { PaymentService } from 'src/app/services/payment.service';
+import { Customer } from 'src/app/interfaces/vocabulary';
 
 @Component({
   selector: 'app-billing',
@@ -8,20 +15,35 @@ import { BillingDialogComponent } from 'src/app/billing-dialog/billing-dialog.co
   styleUrls: ['./billing.component.scss']
 })
 export class BillingComponent implements OnInit {
-  constructor(private dialog: MatDialog) {}
+  uid = this.authService.uid;
+  isCustomer$: Observable<boolean> = this.vocabularyService
+    .getUser(this.uid)
+    .pipe(map(data => data.isCustomer));
+  customerData$: Observable<Customer> = this.paymentService.getCustomer(
+    this.uid
+  );
+  constructor(
+    private dialog: MatDialog,
+    private vocabularyService: VocabularyService,
+    private authService: AuthService,
+    private paymentService: PaymentService
+  ) {}
 
   ngOnInit() {}
 
-  openDialog() {
+  openSubscribeDialog() {
     this.dialog.open(BillingDialogComponent, {
       width: '640px',
       autoFocus: false,
-      restoreFocus: false,
-      // ここでデータを渡す
-      data: {
-        name: 'taro',
-        card: 123
-      }
+      restoreFocus: false
+    });
+  }
+
+  openChangeDialog() {
+    this.dialog.open(ChangeDialogComponent, {
+      width: '640px',
+      autoFocus: false,
+      restoreFocus: false
     });
   }
 }

--- a/src/app/change-dialog/change-dialog.component.html
+++ b/src/app/change-dialog/change-dialog.component.html
@@ -1,0 +1,24 @@
+<h2 mat-dialog-title>このプランに変更しますか？</h2>
+<mat-dialog-content>
+  <p *ngIf="isCustomer$ | async; else paydetail">
+    変更すると月額課金が中止になり、機能制限がつきます
+  </p>
+  <ng-template #paydetail>
+    <p>変更すると月額課金が開始し、解約しない限り1ヶ月毎に課金が発生します</p>
+  </ng-template>
+</mat-dialog-content>
+
+<mat-dialog-actions>
+  <button mat-button matDialogClose>キャンセル</button>
+  <button
+    *ngIf="isCustomer$ | async; else pay"
+    mat-button
+    matDialogClose
+    (click)="stopSubscribe()"
+  >
+    はい
+  </button>
+  <ng-template #pay>
+    <button mat-button matDialogClose (click)="subscribe()">はい</button>
+  </ng-template>
+</mat-dialog-actions>

--- a/src/app/change-dialog/change-dialog.component.spec.ts
+++ b/src/app/change-dialog/change-dialog.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChangeDialogComponent } from './change-dialog.component';
+
+describe('ChangeDialogComponent', () => {
+  let component: ChangeDialogComponent;
+  let fixture: ComponentFixture<ChangeDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ChangeDialogComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ChangeDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/change-dialog/change-dialog.component.ts
+++ b/src/app/change-dialog/change-dialog.component.ts
@@ -1,0 +1,65 @@
+import { Component, OnInit } from '@angular/core';
+import { PaymentService } from '../services/payment.service';
+import { MatSnackBar } from '@angular/material';
+import { AuthService } from '../services/auth.service';
+import { Observable } from 'rxjs';
+import { VocabularyService } from '../services/vocabulary.service';
+import { map } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-change-dialog',
+  templateUrl: './change-dialog.component.html',
+  styleUrls: ['./change-dialog.component.scss']
+})
+export class ChangeDialogComponent implements OnInit {
+  uid = this.authService.uid;
+  isCustomer$: Observable<boolean> = this.vocabularyService
+    .getUser(this.uid)
+    .pipe(map(data => data.isCustomer));
+  constructor(
+    private paymentService: PaymentService,
+    private snackBar: MatSnackBar,
+    private authService: AuthService,
+    private vocabularyService: VocabularyService
+  ) {}
+
+  ngOnInit() {}
+
+  stopSubscribe() {
+    this.paymentService
+      .unsubscribePlan({
+        userId: this.uid
+      })
+      .then(() => {
+        this.snackBar.open('月額プランを解約しました。', null, {
+          duration: 1000
+        });
+      })
+      .catch(err => {
+        this.snackBar.open('月額プランの解約に失敗しました', null, {
+          duration: 1000
+        });
+      });
+  }
+
+  subscribe() {
+    this.paymentService.getCustomer(this.uid).subscribe(customer => {
+      if (customer.customerId) {
+        this.paymentService
+          .subscribePlan({
+            customerId: customer.customerId
+          })
+          .then(() => {
+            this.snackBar.open('月額プランの登録完了しました', null, {
+              duration: 1000
+            });
+          })
+          .catch(err => {
+            this.snackBar.open('月額プランの登録に失敗しました', null, {
+              duration: 1000
+            });
+          });
+      }
+    });
+  }
+}

--- a/src/app/interfaces/vocabulary.ts
+++ b/src/app/interfaces/vocabulary.ts
@@ -14,6 +14,12 @@ export interface User {
   userName: string;
   createdVocabulary: number;
   likedVocabulary: number;
+  isCustomer: boolean;
+  createdAt: Date;
+}
+export interface Customer {
+  customerId: string;
+  uid: string;
 }
 
 export interface VocabularyWithAuthor extends Vocabulary {

--- a/src/app/services/payment.service.spec.ts
+++ b/src/app/services/payment.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PaymentService } from './payment.service';
+
+describe('PaymentService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: PaymentService = TestBed.get(PaymentService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/payment.service.ts
+++ b/src/app/services/payment.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@angular/core';
+import { AngularFireFunctions } from '@angular/fire/functions';
+import { MatSnackBar } from '@angular/material';
+import { LoadingService } from './loading.service';
+import { AngularFirestore } from '@angular/fire/firestore';
+import { Customer } from '../interfaces/vocabulary';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PaymentService {
+  constructor(
+    private fns: AngularFireFunctions,
+    private snackBar: MatSnackBar,
+    private loadingService: LoadingService,
+    private db: AngularFirestore
+  ) {}
+
+  createCustomer(params: {
+    source: string;
+    email: string;
+    name: string;
+  }): Promise<void> {
+    this.loadingService.toggleLoading(true);
+    const callable = this.fns.httpsCallable('createCustomer');
+    return callable(params)
+      .toPromise()
+      .then(() => {
+        this.snackBar.open('月額プランの登録完了しました', null, {
+          duration: 1000
+        });
+        this.loadingService.toggleLoading(false);
+      })
+      .catch(err => {
+        this.snackBar.open('月額プランの登録に失敗しました', null, {
+          duration: 1000
+        });
+        this.loadingService.toggleLoading(false);
+      });
+  }
+
+  subscribePlan(data: { customerId: string }): Promise<void> {
+    this.loadingService.toggleLoading(true);
+    const callable = this.fns.httpsCallable('subscribePlan');
+    return callable(data)
+      .toPromise()
+      .then(() => this.loadingService.toggleLoading(false));
+  }
+
+  unsubscribePlan(data: { userId: string }): Promise<void> {
+    this.loadingService.toggleLoading(true);
+    const callable = this.fns.httpsCallable('unsubscribePlan');
+    return callable(data)
+      .toPromise()
+      .then(() => this.loadingService.toggleLoading(false));
+  }
+
+  deleteCustomer(customerId: string) {
+    const callable = this.fns.httpsCallable('deleteCustomer');
+    return callable({ customerId }).toPromise();
+  }
+  getCustomer(userId: string): Observable<Customer> {
+    return this.db.doc<Customer>(`customers/${userId}`).valueChanges();
+  }
+}


### PR DESCRIPTION
## 実装内容
- stripe連携
- 月額課金開始、月額課金停止
- 一度月額課金し、解約した人はカード番号入力画面を省略して、ボタン一つで再登録できるようにしました

fix #13 

ご確認お願いいたします。

## 挙動
[![Image from Gyazo](https://i.gyazo.com/0016a9d518547e7daab0b3899a8e73b3.gif)](https://gyazo.com/0016a9d518547e7daab0b3899a8e73b3)
